### PR TITLE
:bug: 将棋エンジンの思考結果の表記修正

### DIFF
--- a/src/components/engine/info/Columns.test.tsx
+++ b/src/components/engine/info/Columns.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import shortid from 'shortid'
+import { Info } from '../../../model/engine/Info'
+import { MoveProps } from '../../../model/events/MoveProps'
+import { Fu0 } from '../../../model/shogi/Piece'
+import { defaultStore } from '../../../store/Store'
+import { shallow } from '../../../testutils/component-helper'
+import Columns from './Columns'
+
+it('思考結果が空なら表示なし', async () => {
+  const store = defaultStore()
+  const wrapper = shallow(() => <Columns />, store)
+  expect(wrapper.find('.EngineInfoColumn')).toHaveLength(0)
+})
+
+it('評価値だけでも表示できる', async () => {
+  const store = defaultStore()
+  const score = -50000
+  store.engineState.result = [info([], score)]
+  const wrapper = shallow(() => <Columns />, store)
+  expect(wrapper.find('.EngineInfoColumn')).toHaveLength(1)
+  expect(wrapper.find('.EngineInfoRow')).toHaveLength(2)
+  expect(wrapper.find('.EngineInfoRowLabel')).toHaveLength(2)
+  expect(wrapper.find('.EngineInfoRowContent')).toHaveLength(1)
+  expect(wrapper.text()).toContain(score)
+  expect(wrapper.text()).toContain('読み')
+})
+
+it('思考結果も表示できる', async () => {
+  const store = defaultStore()
+  store.engineState.result = [
+    info([
+      {
+        pos: store.gameState.currentMove.pos,
+        source: { column: 6, row: 6 },
+        dest: { column: 6, row: 5 },
+        piece: Fu0,
+      },
+    ]),
+  ]
+  const wrapper = shallow(() => <Columns />, store)
+  expect(wrapper.find('.EngineInfoColumn')).toHaveLength(1)
+  expect(wrapper.find('.EngineInfoRow')).toHaveLength(2)
+  expect(wrapper.find('.EngineInfoRowLabel')).toHaveLength(2)
+  expect(wrapper.find('.EngineInfoRowContent')).toHaveLength(2)
+  expect(wrapper.text()).toContain('読み')
+  expect(wrapper.text()).toContain('７六歩')
+})
+
+function info(moves: MoveProps[], score?: number): Info {
+  return {
+    id: shortid.generate(),
+    values: new Map(),
+    score: score || 100,
+    moves,
+  }
+}

--- a/src/components/engine/info/Columns.tsx
+++ b/src/components/engine/info/Columns.tsx
@@ -13,7 +13,7 @@ const Columns: FC = () => {
   const columns = result.map(i => {
     let prevDest: Point = gameState.currentMove.dest
     const moves = i.moves.map((m, n) => {
-      if (prevDest) m.prevDest = prevDest
+      m.prevDest = prevDest
       const kifu = genKifuString(m)
       prevDest = m.dest
       // TODO: key

--- a/src/components/engine/info/Columns.tsx
+++ b/src/components/engine/info/Columns.tsx
@@ -11,7 +11,7 @@ const Columns: FC = () => {
   if (!result) return <div />
 
   const columns = result.map(i => {
-    let prevDest: Point | null = gameState.prevDestination
+    let prevDest: Point = gameState.currentMove.dest
     const moves = i.moves.map((m, n) => {
       if (prevDest) m.prevDest = prevDest
       const kifu = genKifuString(m)

--- a/src/components/engine/info/SideInfo.test.tsx
+++ b/src/components/engine/info/SideInfo.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { shallow } from '../../../testutils/component-helper'
+import SideInfo from './SideInfo'
+
+it('思考結果が空なら表示なし', async () => {
+  const wrapper = shallow(() => <SideInfo />)
+  expect(wrapper.find('.EngineSideInfo')).toHaveLength(1)
+  expect(wrapper.find('.EngineSideInfoContainer')).toHaveLength(1)
+  expect(wrapper.find('Columns')).toHaveLength(1)
+})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,5 +10,5 @@ ReactDOM.render(<App />, document.getElementById('root'))
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: http://bit.ly/CRA-PWA
+// Learn more about service workers: https://cra.link/PWA
 serviceWorker.register()

--- a/src/store/GameState.ts
+++ b/src/store/GameState.ts
@@ -33,11 +33,6 @@ export interface GameState {
   // 棋譜
   kifu: Kifu
 
-  // 前回の移動先。棋譜で `同歩` のような文字列を作成するため
-  // ただし、通常は使われることはない。将棋ソフトから読みを受け取った場合、最初の手を`同歩`の
-  // ように表現するのが難しいため、仕方なく作ったもの。
-  prevDestination: Point | null
-
   // 棋譜の現在表示局面を返す
   currentMove: Move
 

--- a/src/store/impl/GameState.ts
+++ b/src/store/impl/GameState.ts
@@ -25,7 +25,6 @@ export class DefaultGameState implements GameState {
   @observable confirm: Confirm | null = null
   @observable moveTargets: Point[] = []
   @observable kifu: Kifu = newKifu()
-  @observable prevDestination: Point | null = null
 
   @computed get currentMove(): Move {
     return getCurrent(this.kifu)
@@ -78,7 +77,6 @@ export class DefaultGameState implements GameState {
     const dest: Point = { row: p.row, column: p.column }
 
     const moveAndUpdateState = (piece: Piece, promote?: boolean) => {
-      this.prevDestination = dest
       const moveProps: MoveProps = {
         pos: this.currentMove.pos,
         source,


### PR DESCRIPTION
一番上の棋譜表記が `同~` に対応できていなかった